### PR TITLE
feat: prefer TensorrtExecutionProvider in ORT benchmark session

### DIFF
--- a/src/rfdetr/export/benchmark.py
+++ b/src/rfdetr/export/benchmark.py
@@ -404,7 +404,15 @@ def main(
     if path.endswith(".onnx"):
         import onnxruntime as nxrun
 
-        sess = nxrun.InferenceSession(path, providers=["CUDAExecutionProvider"])
+        available = nxrun.get_available_providers()
+        providers = []
+        if "TensorrtExecutionProvider" in available:
+            providers.append("TensorrtExecutionProvider")
+        if "CUDAExecutionProvider" in available:
+            providers.append("CUDAExecutionProvider")
+        providers.append("CPUExecutionProvider")
+        logger.info("Using ORT execution providers: %s", providers)
+        sess = nxrun.InferenceSession(path, providers=providers)
         infer_onnx(sess, coco_evaluator, time_profile, prefix, img_list, device=f"cuda:{device}", repeats=repeats)
     elif path.endswith(".engine"):
         model = TRTInference(path, sync_mode=True, device=f"cuda:{device}")


### PR DESCRIPTION
## Summary

- Replaces the hard-coded `["CUDAExecutionProvider"]` in `benchmark.py` with dynamic provider selection at runtime
- Queries `onnxruntime.get_available_providers()` and builds a priority-ordered list: `TensorrtExecutionProvider` → `CUDAExecutionProvider` → `CPUExecutionProvider` (always present as fallback)
- Logs selected providers so users can see what is being used
- `TensorrtExecutionProvider` fuses and compiles the ONNX graph inside TRT without a separate `trtexec` engine-build step, typically reducing latency

## Test plan

- [ ] Install `onnxruntime-gpu` with TRT support; verify `TensorrtExecutionProvider` is selected and inference runs
- [ ] Install `onnxruntime-gpu` without TRT; verify fallback to `CUDAExecutionProvider`
- [ ] Install CPU-only `onnxruntime`; verify fallback to `CPUExecutionProvider`

🤖 Generated with [Claude Code](https://claude.com/claude-code)