### PR TITLE
feat: add fp16 parameter to ONNX export for half-precision models

### DIFF
--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -770,6 +770,7 @@ class RFDETR:
         batch_size: int = 1,
         dynamic_batch: bool = False,
         patch_size: int | None = None,
+        fp16: bool = False,
     ) -> None:
         """Export the trained model to ONNX format.
 
@@ -793,6 +794,9 @@ class RFDETR:
                 ``model_config.patch_size`` (typically 14 or 16). When provided
                 explicitly it must match the instantiated model's patch size.
                 Shape divisibility is validated against ``patch_size * num_windows``.
+            fp16: If ``True``, export the model in float16 precision. The output
+                file will be named ``*_fp16.onnx``. Produces a ~2x smaller ONNX
+                file and enables FP16 kernels in ONNX Runtime.
         """
         logger.info("Exporting model to ONNX format")
         try:
@@ -827,6 +831,8 @@ class RFDETR:
             shape = _validate_shape_dims(shape, block_size, patch_size, num_windows)
 
         input_tensors = make_infer_image(infer_dir, shape, batch_size, device).to(device)
+        if fp16:
+            input_tensors = input_tensors.half()
         input_names = ["input"]
         if backbone_only:
             output_names = ["features"]
@@ -876,6 +882,7 @@ class RFDETR:
             verbose=verbose,
             opset_version=opset_version,
             variant_name=getattr(self, "size", None),
+            fp16=fp16,
         )
 
         logger.info(f"Successfully exported ONNX model to: {output_file}")

--- a/src/rfdetr/export/_onnx/exporter.py
+++ b/src/rfdetr/export/_onnx/exporter.py
@@ -62,6 +62,7 @@ def export_onnx(
     verbose: bool = True,
     opset_version: int = 17,
     variant_name: str | None = None,
+    fp16: bool = False,
 ) -> str:
     """Export a model to ONNX.
 
@@ -79,6 +80,8 @@ def export_onnx(
             When provided, the exported file is named ``{variant_name}.onnx`` or
             ``{variant_name}-backbone.onnx`` (when ``backbone_only=True``) instead
             of the generic ``inference_model.onnx`` or ``backbone_model.onnx``.
+        fp16: If ``True``, cast the model and input tensors to float16 before
+            export. The output file will be named ``*_fp16.onnx``.
 
     Returns:
         Path to the exported ONNX model.
@@ -89,11 +92,20 @@ def export_onnx(
         export_name = f"{variant_name}-backbone" if backbone_only else variant_name
     else:
         export_name = "backbone_model" if backbone_only else "inference_model"
+    if fp16:
+        export_name = f"{export_name}_fp16"
     output_file = os.path.join(output_dir, f"{export_name}.onnx")
 
     # Prepare model for export
     if hasattr(model, "export"):
         model.export()
+
+    if fp16:
+        model.half()
+        if isinstance(input_tensors, torch.Tensor):
+            input_tensors = input_tensors.half()
+        else:
+            input_tensors = [t.half() for t in input_tensors]
 
     export_kwargs = {}
     if "dynamo" in inspect.signature(torch.onnx.export).parameters:


### PR DESCRIPTION
## Summary

- Adds `fp16: bool = False` to `RFDETR.export()` and `export_onnx()`
- When `fp16=True`: casts model and input tensors to `float16` before tracing, and names the output `*_fp16.onnx`
- Produces a ~2× smaller ONNX file and enables FP16 kernels in ONNX Runtime directly (not only via TRT)
- The model passed to export is already a `deepcopy`, so the original is never mutated

## Test plan

- [ ] `model.export(fp16=True)` produces a `*_fp16.onnx` file
- [ ] All weights in the exported ONNX are `float16`
- [ ] `model.export(fp16=False)` (default) behaviour is unchanged
- [ ] ORT inference on the FP16 ONNX produces valid detections

🤖 Generated with [Claude Code](https://claude.com/claude-code)