### PR TITLE
feat: add optimize flag to re-enable OnnxOptimizer graph constant folding

### DIFF
--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -770,6 +770,7 @@ class RFDETR:
         batch_size: int = 1,
         dynamic_batch: bool = False,
         patch_size: int | None = None,
+        optimize: bool = False,
     ) -> None:
         """Export the trained model to ONNX format.
 
@@ -793,6 +794,9 @@ class RFDETR:
                 ``model_config.patch_size`` (typically 14 or 16). When provided
                 explicitly it must match the instantiated model's patch size.
                 Shape divisibility is validated against ``patch_size * num_windows``.
+            optimize: When ``True``, run :class:`~rfdetr.export._onnx.exporter.OnnxOptimizer`
+                constant folding and shape inference on the exported ONNX graph
+                (overwrites the file in-place). Requires the ``rfdetr[onnx]`` extras.
         """
         logger.info("Exporting model to ONNX format")
         try:
@@ -876,6 +880,7 @@ class RFDETR:
             verbose=verbose,
             opset_version=opset_version,
             variant_name=getattr(self, "size", None),
+            optimize=optimize,
         )
 
         logger.info(f"Successfully exported ONNX model to: {output_file}")

--- a/src/rfdetr/export/_onnx/exporter.py
+++ b/src/rfdetr/export/_onnx/exporter.py
@@ -62,6 +62,7 @@ def export_onnx(
     verbose: bool = True,
     opset_version: int = 17,
     variant_name: str | None = None,
+    optimize: bool = False,
 ) -> str:
     """Export a model to ONNX.
 
@@ -79,6 +80,10 @@ def export_onnx(
             When provided, the exported file is named ``{variant_name}.onnx`` or
             ``{variant_name}-backbone.onnx`` (when ``backbone_only=True``) instead
             of the generic ``inference_model.onnx`` or ``backbone_model.onnx``.
+        optimize: When ``True``, run :class:`OnnxOptimizer` constant folding and
+            shape inference on the exported graph (overwrites the file in-place).
+            Requires the ``rfdetr[onnx]`` extras (``onnx``, ``onnx-graphsurgeon``,
+            ``polygraphy``).
 
     Returns:
         Path to the exported ONNX model.
@@ -117,6 +122,16 @@ def export_onnx(
     )
 
     logger.info(f"\nSuccessfully exported ONNX model: {output_file}")
+
+    if optimize:
+        try:
+            opt = OnnxOptimizer(output_file)
+            opt.common_opt()
+            opt.save_onnx(output_file)
+            logger.info(f"ONNX graph optimized: {output_file}")
+        except ImportError:
+            logger.warning("ONNX graph optimization skipped: install rfdetr[onnx] for full optimization support.")
+
     return output_file
 
 


### PR DESCRIPTION
## Summary

- Adds `optimize: bool = False` to `RFDETR.export()` and `export_onnx()`
- When `optimize=True`, runs `OnnxOptimizer.common_opt()` on the exported ONNX in-place: constant folding via `polygraphy`, graph cleanup via `onnx-graphsurgeon`, and shape inference
- `OnnxOptimizer` was already fully implemented but disconnected when `--simplify` was deprecated; this re-wires it as a distinct opt-in flag
- Gracefully skips with a `logger.warning` if `rfdetr[onnx]` extras are not installed
- Smaller, cleaner graphs improve TRT kernel selection and reduce ORT overhead

## Test plan

- [ ] `model.export(optimize=True)` produces a valid ONNX with fewer nodes
- [ ] `model.export(optimize=False)` (default) behaviour is unchanged
- [ ] Without `onnx-graphsurgeon`/`polygraphy`, a warning is logged and export completes without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)